### PR TITLE
fix-windows-only-directory-separator

### DIFF
--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -1,10 +1,10 @@
 <?php
-require_once __DIR__.'\..\config\app.php';
+require_once __DIR__.'/../config/app.php';
 
 if(!function_exists('view')){
     function view($view = null, $data = []) {
         global $app_config;
         extract($data);
-        require_once __DIR__.'\..\views\\'.strtolower($view).'.php';
+        require_once __DIR__.'/../views/'.strtolower($view).'.php';
     }
 }


### PR DESCRIPTION
Don't know why the original repo switched owners? But either way, this PR fixes the 
windows only backslashes in the helper.php path so it can run on other platforms